### PR TITLE
Fix runtime dependency and update upstream URLs

### DIFF
--- a/org.gtk.Gtk3theme.Breeze-Dark.appdata.xml
+++ b/org.gtk.Gtk3theme.Breeze-Dark.appdata.xml
@@ -7,5 +7,5 @@
   <description>
     <p>Breeze Gtk theme that matches the KDE breeze theme.</p>
   </description>
-  <url type="homepage">https://quickgit.kde.org/?p=breeze-gtk.git</url>
+  <url type="homepage">https://invent.kde.org/plasma/breeze-gtk</url>
 </component>

--- a/org.gtk.Gtk3theme.Breeze-Dark.json
+++ b/org.gtk.Gtk3theme.Breeze-Dark.json
@@ -1,7 +1,7 @@
 {
   "id": "org.gtk.Gtk3theme.Breeze-Dark",
   "branch": "3.22",
-  "runtime": "org.freedesktop.Sdk",
+  "runtime": "org.freedesktop.Platform",
   "build-extension": true,
   "sdk": "org.freedesktop.Sdk",
   "runtime-version": "19.08",

--- a/org.gtk.Gtk3theme.Breeze-Dark.json
+++ b/org.gtk.Gtk3theme.Breeze-Dark.json
@@ -38,6 +38,6 @@
           "path": "org.gtk.Gtk3theme.Breeze-Dark.appdata.xml"
         }
       ]
-  }
+    }
   ]
 }

--- a/org.gtk.Gtk3theme.Breeze-Dark.json
+++ b/org.gtk.Gtk3theme.Breeze-Dark.json
@@ -19,7 +19,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://anongit.kde.org/breeze-gtk.git",
+          "url": "https://invent.kde.org/plasma/breeze-gtk.git",
           "tag": "v5.14.3"
         }
       ]


### PR DESCRIPTION
Hello,

I noticed a dependency issue with apps that depend on org.gtk.Gtk3theme.Breeze-Dark. The Breeze-Dark manifest file currently has a `runtime` field that depends on the Freedesktop SDK, but I believe it should depend on the Platform variant, which is the convention for runtimes. This was causing some unexpected behavior for me on Debian 10 when running `flatpak update` and `flatpak uninstall --unused` where it would install and uninstall the Freedesktop SDK as a runtime depenency of Breeze-Dark. I had verified this issue with both com.axosoft.GitKraken (depends on GNOME 40) and com.github.arshubham.gitignore (depends on GNOME 3.38) a few weeks ago, although for some reason I can't reproduce the symptoms anymore. Neither GitKraken or gitignore directly require Breeze-Dark, so Breeze-Dark is an indirect dependency. I believe it was the GNOME runtimes (or its dependencies) that actually require Breeze-Dark.

Included in this pull request I also updated the upstream URLs (see the commit message for details) and fixed indentation.

Below are some samples of the symptoms I was experiencing.

- - -

From a clean base, install GitKraken:
```
$ flatpak list --all

$ flatpak install flathub com.axosoft.GitKraken
Looking for matches…
Required runtime for com.axosoft.GitKraken/x86_64/stable (runtime/org.gnome.Platform/x86_64/40) found in remote flathub
Do you want to install it? [Y/n]: y

com.axosoft.GitKraken permissions:
    ipc     network     pcsc     pulseaudio     ssh-auth     x11     dri     file access [1]     dbus access [2]    tags [3]

    [1] /media, /mnt, /run/media, home, xdg-run/gvfs, xdg-run/gvfsd
    [2] org.freedesktop.Flatpak, org.freedesktop.Notifications, org.freedesktop.secrets, org.gtk.vfs, org.gtk.vfs.*
    [3] proprietary


        ID                                              Arch              Branch            Remote             Download
 1. [✓] org.gnome.Platform                              x86_64            40                flathub            349.5 MB / 363.9 MB
 2. [✓] org.gnome.Platform.Locale                       x86_64            40                flathub             16.9 kB / 333.7 MB
 3. [✓] org.freedesktop.Platform.GL.default             x86_64            20.08             flathub            106.4 MB / 106.4 MB
 4. [✓] org.gtk.Gtk3theme.Breeze-Dark                   x86_64            3.22              flathub            120.7 kB / 156.9 kB
 5. [✓] org.freedesktop.Platform.VAAPI.Intel            x86_64            20.08             flathub             11.6 MB / 11.6 MB
 6. [✓] org.freedesktop.Platform.openh264               x86_64            2.0               flathub              1.5 MB / 1.5 MB
 7. [✓] com.axosoft.GitKraken                           x86_64            stable            flathub             88.0 MB / 93.2 MB

Installation complete.
```

Now when checking for updates it wants to install additional SDK dependencies:
```
$ flatpak update
Looking for updates…
Required runtime for org.gtk.Gtk3theme.Breeze-Dark/x86_64/3.22 (runtime/org.freedesktop.Sdk/x86_64/19.08) found in remote flathub
Do you want to install it? [Y/n]: y


        ID                                              Arch              Branch            Remote             Download
 1. [✓] org.freedesktop.Sdk                             x86_64            19.08             flathub            525.5 MB / 578.9 MB
 2. [✓] org.freedesktop.Platform.GL.default             x86_64            19.08             flathub             89.1 MB / 89.1 MB
 3. [✓] org.freedesktop.Sdk.Locale                      x86_64            19.08             flathub             16.7 kB / 322.4 MB
 4. [✓] org.freedesktop.Platform.VAAPI.Intel            x86_64            19.08             flathub              8.7 MB / 8.7 MB

Installation complete.
```

But then it still considers those dependencies to be unused:
```
$ flatpak uninstall --unused


        ID                                             Arch             Branch
 1. [-] org.freedesktop.Platform.GL.default            x86_64           19.08
 2. [-] org.freedesktop.Platform.VAAPI.Intel           x86_64           19.08
 3. [-] org.freedesktop.Sdk                            x86_64           19.08
 4. [-] org.freedesktop.Sdk.Locale                     x86_64           19.08

Uninstall complete.
```

Checking for updates will loop through this cycle again. Declining the updates will error out, which will prevent other unrelated updates from being installed:
```
$ flatpak update
Looking for updates…
Required runtime for org.gtk.Gtk3theme.Breeze-Dark/x86_64/3.22 (runtime/org.freedesktop.Sdk/x86_64/19.08) found in remote flathub
Do you want to install it? [Y/n]: n
error: The application org.gtk.Gtk3theme.Breeze-Dark/x86_64/3.22 requires the runtime org.freedesktop.Sdk/x86_64/19.08 which is not installed
```
