### PR TITLE
Add EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,5 @@
 {
-    "skip-icons-check": true
+    "skip-icons-check": true,
+    "end-of-life": "This theme has been replaced by org.gtk.Gtk3theme.Breeze, see README for workaround on using system color schemes. https://github.com/flathub/org.gtk.Gtk3theme.Breeze#workarounds",
+    "end-of-life-rebase": "org.gtk.Gtk3theme.Breeze"
 }


### PR DESCRIPTION
> KDE Plasma doesn't have a separate Breeze-Dark GTK theme selection anymore with color schemes generating their own colors.css file for GTK3. Alternative is to use [org.gtk.Gtk3theme.Breeze](https://github.com/flathub/org.gtk.Gtk3theme.Breeze). Resolves https://github.com/flathub/org.gtk.Gtk3theme.Breeze-Dark/issues/4.

Reopening #6 here, since I accidentally deleted the repo for it.